### PR TITLE
Fixed eeprom detection in the device tree

### DIFF
--- a/openpower/patches/vesnin-patches/hostboot-p8/hostboot-1007-Fixed-eeprom-detection-in-the-device-tree.patch
+++ b/openpower/patches/vesnin-patches/hostboot-p8/hostboot-1007-Fixed-eeprom-detection-in-the-device-tree.patch
@@ -1,0 +1,40 @@
+From 6a504039405a862cf0793b5e354ee078df8975c0 Mon Sep 17 00:00:00 2001
+From: Maxim Polyakov <m.polyakov@yadro.com>
+Date: Mon, 17 Dec 2018 19:57:35 +0300
+Subject: [PATCH] Fixed eeprom detection in the device tree
+
+This commit fixed bug with determining the atmel compatible eeprom
+in the device tree.
+In addition, I added support for eeprom atmel-24c512 to the device
+tree. Now the Hostboot sets the correct size (64Kb) of the mvpd,
+cvpd, pvpd in the device tree for the i2c OS driver.
+
+Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>
+---
+ src/usr/devtree/bld_devtree.C | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/usr/devtree/bld_devtree.C b/src/usr/devtree/bld_devtree.C
+index 1959020..e7ea33a 100644
+--- a/src/usr/devtree/bld_devtree.C
++++ b/src/usr/devtree/bld_devtree.C
+@@ -443,6 +443,7 @@ void add_i2c_info( const TARGETING::Target* i_targ,
+     } atmel_ids[] = {
+         { "atmel,24c128", 16*KILOBYTE, 2 },
+         { "atmel,24c256", 32*KILOBYTE, 2 },
++        { "atmel,24c512", 64*KILOBYTE, 2 },
+         { "atmel,24c02",  256,         1 },
+ 
+         //Currently our minimum is 1KB, even for the 256 byte SPD
+@@ -629,7 +630,7 @@ void add_i2c_info( const TARGETING::Target* i_targ,
+                      a++ )
+                 {
+                     if( (atmel_ids[a].byteSize == (KILOBYTE*eep2->sizeKB))
+-                        || (atmel_ids[a].addrBytes == eep2->addrBytes) )
++                        && (atmel_ids[a].addrBytes == eep2->addrBytes) )
+                     {
+                         l_compat = atmel_ids[a].name;
+                         l_foundit = true;
+-- 
+2.7.4
+


### PR DESCRIPTION
Added the Hostboot patch that
1. fixes bug with determining the atmel compatible eeprom in the
device tree;
2. adds atmel-24c512 id to atmel_ids[] list in the device tree.

Now the Hostboot sets the correct size (64Kb) of the mvpd, cvpd,
pvpd in the device tree for the i2c OS driver.

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>