### PR TITLE
vesnin: Adds sreset support for Vesnin server

### DIFF
--- a/openpower/patches/vesnin-patches/skiboot/skiboot-1001-core-direct-controls.c-Adds-sreset-support-for-P8.patch
+++ b/openpower/patches/vesnin-patches/skiboot/skiboot-1001-core-direct-controls.c-Adds-sreset-support-for-P8.patch
@@ -1,0 +1,53 @@
+From f49807a16883136a5f88f74ff6635dbc4a697726 Mon Sep 17 00:00:00 2001
+From: Maxim Polyakov <m.polyakov@yadro.com>
+Date: Fri, 18 Jan 2019 17:49:37 +0300
+Subject: [PATCH] core/direct-controls.c: Adds sreset support for P8
+
+We use the NMI to call kdump in the Vesnin server (P8) in the event
+of the Linux crash. The NMI handler sends the SRESET signal to OPAL
+to correctly stop all processor threads after kdump. In this case,
+it is not necessary to return control to the system, since the
+Linux has been already crashed. This commit adds the
+opal_signal_system_reset signal to OPAL for P8 servers.
+
+Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>
+---
+ core/direct-controls.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/core/direct-controls.c b/core/direct-controls.c
+index 04b93a1..bc56a76 100644
+--- a/core/direct-controls.c
++++ b/core/direct-controls.c
+@@ -824,7 +824,7 @@ int64_t opal_signal_system_reset(int cpu_nr)
+ 	struct cpu_thread *cpu;
+ 	int64_t ret;
+ 
+-	if (proc_gen != proc_gen_p9)
++	if (proc_gen != proc_gen_p9 && proc_gen != proc_gen_p8)
+ 		return OPAL_UNSUPPORTED;
+ 
+ 	/*
+@@ -856,13 +856,15 @@ void direct_controls_init(void)
+ 	if (chip_quirk(QUIRK_MAMBO_CALLOUTS))
+ 		return;
+ 
+-	if (proc_gen != proc_gen_p9)
++	if (proc_gen != proc_gen_p9 && proc_gen != proc_gen_p8)
+ 		return;
+ 
+ 	/* DD1 has some sreset quirks we do not support */
+-	version = mfspr(SPR_PVR);
+-	if (is_power9n(version) && PVR_VERS_MAJ(version) == 1)
+-		return;
++	if (proc_gen == proc_gen_p9) {		
++		version = mfspr(SPR_PVR);
++		if (is_power9n(version) && PVR_VERS_MAJ(version) == 1)
++			return;
++	}
+ 
+ 	opal_register(OPAL_SIGNAL_SYSTEM_RESET, opal_signal_system_reset, 1);
+ }
+-- 
+2.7.4
+


### PR DESCRIPTION
This commit includes the skiboot patch that adds SRESET signal to
OPAL-P8 to correctly stop all processor threads after kdump in
Vesnin servers.

Resolves SRV-526

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>