### PR TITLE
vesnin: Fix address-cells in opal DT node

### DIFF
--- a/openpower/patches/vesnin-patches/skiboot/skiboot-1001-core-opal-Fix-address-cells-in-opal-node-in-DT.patch
+++ b/openpower/patches/vesnin-patches/skiboot/skiboot-1001-core-opal-Fix-address-cells-in-opal-node-in-DT.patch
@@ -1,0 +1,35 @@
+From b712abf43a48a4a3806bd202ee28fb3f9333aaaf Mon Sep 17 00:00:00 2001
+From: Maxim Polyakov <m.polyakov@yadro.com>
+Date: Tue, 26 Mar 2019 17:52:46 +0300
+Subject: [PATCH] core/opal: Fix address-cells in opal node in DT
+
+This patch fix this FWTS warning:
+
+Warning (reg_format): "reg" property in /ibm,opal/flash at 0 has
+invalid length (8 bytes) (#address-cells == 0, #size-cells == 0)
+
+See more in https://github.com/open-power/skiboot/issues/47
+
+It has been tested on Vesnin P8 server.
+
+Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>
+---
+ core/opal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/opal.c b/core/opal.c
+index 624e2a2..9271b07 100644
+--- a/core/opal.c
++++ b/core/opal.c
+@@ -406,7 +406,7 @@ void add_opal_node(void)
+ 		(uint64_t)(cpu_max_pir + 1) * STACK_SIZE) - SKIBOOT_BASE;
+ 
+ 	opal_node = dt_new_check(dt_root, "ibm,opal");
+-	dt_add_property_cells(opal_node, "#address-cells", 0);
++	dt_add_property_cells(opal_node, "#address-cells", 1);
+ 	dt_add_property_cells(opal_node, "#size-cells", 0);
+ 
+ 	if (proc_gen < proc_gen_p9)
+-- 
+2.7.4
+


### PR DESCRIPTION
Adds patch for skiboot that fixes this FWTS warning:

Warning (reg_format): "reg" property in /ibm,opal/flash at 0 has
invalid length (8 bytes) (#address-cells == 0, #size-cells == 0)

See more in https://github.com/open-power/skiboot/issues/47
This resolve SRV-553

Patchwork: https://patchwork.ozlabs.org/patch/1066930/

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>