### PR TITLE
vesnin: Fix IBSCOM_MCS_BASE_ADDR formatting

### DIFF
--- a/openpower/patches/vesnin-patches/machine_xml/0001-Fix-IBSCOM_MCS_BASE_ADDR-formatting.patch
+++ b/openpower/patches/vesnin-patches/machine_xml/0001-Fix-IBSCOM_MCS_BASE_ADDR-formatting.patch
@@ -1,0 +1,100 @@
+From 65ae4fddaaf02645853e6eeff187d687b8321bd5 Mon Sep 17 00:00:00 2001
+From: Artem Senichev <a.senichev@yadro.com>
+Date: Tue, 2 Apr 2019 14:19:33 +0300
+Subject: [PATCH] Fix IBSCOM_MCS_BASE_ADDR formatting
+
+New Ubuntu docker image contains the latest version of XML::Simple module
+for Perl. That module has an error in the line break handling procedure.
+
+Signed-off-by: Artem Senichev <a.senichev@yadro.com>
+---
+ vesnin.xml | 24 ++++++++----------------
+ 1 file changed, 8 insertions(+), 16 deletions(-)
+
+diff --git a/vesnin.xml b/vesnin.xml
+index fe693f4..c9837a0 100644
+--- a/vesnin.xml
++++ b/vesnin.xml
+@@ -17102,8 +17102,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -17154,8 +17153,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -17206,8 +17204,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -17258,8 +17255,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -18385,8 +18381,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -18437,8 +18432,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -18489,8 +18483,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+@@ -18541,8 +18534,7 @@
+ 		</attribute>
+ 		<attribute>
+ 			<id>IBSCOM_MCS_BASE_ADDR</id>
+-			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
+-			</default>
++			<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
+ 		</attribute>
+ 		<attribute>
+ 			<id>MODEL</id>
+-- 
+2.21.0
+


### PR DESCRIPTION
New Ubuntu docker image contains the latest version of XML::Simple module
for Perl. That module has an error in the line break handling procedure.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>