### PR TITLE
vesnin: remove #address/#size-cell in bmc dt node

### DIFF
--- a/openpower/patches/vesnin-patches/hostboot-p8/hostboot-1004-devtree-remove-address-size-cell-from-bmc-node.patch
+++ b/openpower/patches/vesnin-patches/hostboot-p8/hostboot-1004-devtree-remove-address-size-cell-from-bmc-node.patch
@@ -1,0 +1,41 @@
+From 3ac0ef40159b39a7f881934aac653088a5e81aa8 Mon Sep 17 00:00:00 2001
+From: Maxim Polyakov <m.polyakov@yadro.com>
+Date: Mon, 8 Apr 2019 19:14:19 +0300
+Subject: [PATCH] devtree: remove #address/size cell from "bmc" node
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The child node ("sensors") from “bmc” in the device tree doesn`t
+contain "reg" property with address information. For this reason,
+the properties #address-cell and #size-cell isn`t needed in "bmc"
+node. Commit removes these properties.
+
+In addition, it allows the dtc utility to get rid of the warning:
+
+(avoid_unnecessary_addr_size): /bmc: unnecessary #address-cells
+/#size-cells without "ranges" or child "reg" property
+
+Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>
+---
+ src/usr/devtree/bld_devtree.C | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/src/usr/devtree/bld_devtree.C b/src/usr/devtree/bld_devtree.C
+index ec0a6ce..9e59828 100644
+--- a/src/usr/devtree/bld_devtree.C
++++ b/src/usr/devtree/bld_devtree.C
+@@ -2688,10 +2688,6 @@ errlHndl_t bld_fdt_bmc(devTree * i_dt, bool i_smallTree)
+         bmcNode = i_dt->addNode(rootNode, bmcNodeName);
+     }
+ 
+-    /* Add the # address & size cell properties to /bmc node. */
+-    i_dt->addPropertyCell32(bmcNode, "#address-cells", 1);
+-    i_dt->addPropertyCell32(bmcNode, "#size-cells", 0);
+-
+     i_dt->addPropertyString(bmcNode, "name", bmcNodeName );
+ 
+     /* create a node to hold the sensors */
+-- 
+2.7.4
+


### PR DESCRIPTION
The child node ("sensors") from “bmc” in the device tree doesn`t
contain "reg" property with address information. For this reason,
the properties #address-cell and #size-cell isn`t needed in "bmc"
node. The patch for the hostboot removes these properties.

In addition, it allows the dtc utility to get rid of the warning:

(avoid_unnecessary_addr_size): /bmc: unnecessary #address-cells
/#size-cells without "ranges" or child "reg" property

https://github.com/open-power/hostboot/pull/170

Signed-off-by: Maxim Polyakov <m.polyakov@yadro.com>