### PR TITLE
vesnin: Fix CI script

### DIFF
--- a/ci/yadro.sh
+++ b/ci/yadro.sh
@@ -107,6 +107,7 @@ function build_image {
   local ccache="$4"
   shift 4
   local optargs="$*"
+  local version="$(version_string ${machine})"
 
   # Get buildroot as submodule
   if [[ ! -f ${OPBUILD_ROOT}/buildroot/Makefile ]]; then
@@ -119,7 +120,10 @@ function build_image {
 
   # Setup version string, op-build system automatically adds machine name as a
   # platform, so we have to remove it from version string to avoid duplicates
-  cmd+=" OPBUILD_VERSION=$(version_string ${machine} | sed 's/^${machine}-//')"
+  cmd+=" OPBUILD_VERSION=${version#${machine}-}"
+
+  # Set Hostboot image id using the firmware version instead of hostboot one
+  cmd+=" HOSTBOOT_IMAGEID=${version}"
 
   # Set OpenPOWER build configuration directory
   cmd+=" BR2_EXTERNAL=${OPBUILD_ROOT}/openpower"
@@ -164,18 +168,29 @@ function create_packages {
   local dbg_dir="${output}/fw_debug"
   local sysroot="${output}/host/powerpc64le-buildroot-linux-gnu/sysroot"
   local hbi_dir="${sysroot}/hostboot_build_images"
+
   echo "Prepare debug directory..."
   rsync --archive --delete "${hbi_dir}/" "${dbg_dir}/"
+
   echo "Create MRW report..."
   local mrw_dir="${sysroot}/openpower_mrw_scratch"
   perl -I "${hbi_dir}" "${hbi_dir}/processMrw.pl" -x "${mrw_dir}/${machine}.xml" -r
   mv "${mrw_dir}/${machine}.rpt" "${dbg_dir}"
+
   echo "Add OCC strings file..."
-  local occ_strings="$(ls ${output}/build/occ-*/obj/occStringFile)"
-  [[ -n "${occ_strings}" ]] || occ_strings="$(ls ${output}/build/occ-*/src/occStringFile)"
+  local occ_strings="$(ls ${output}/build/occ-*/obj/occStringFile 2>/dev/null || true)"
+  if [[ -z "${occ_strings}" ]]; then
+    occ_strings="$(ls ${output}/build/occ-*/src/occStringFile 2>/dev/null || true)"
+    if [[ -z "${occ_strings}" ]]; then
+      echo "OCC strings file not found" >&2
+      return 1
+    fi
+  fi
+
   cp -fu "${occ_strings}" "${dbg_dir}"
   echo "Add skiboot map file..."
   cp -fu "$(ls ${output}/build/skiboot-*/skiboot.map)" "${dbg_dir}"
+
   echo "Create debug package..."
   mkdir -p "${pkgdir}"
   tar czf "${pkgdir}/opfw-${version}-debug.tar.gz" -C "$(dirname "${dbg_dir}")" "$(basename "${dbg_dir}")"

--- a/openpower/patches/vesnin-patches/hostboot-p8/hostboot-1005-Allow-to-set-image-id-string-via-environment.patch
+++ b/openpower/patches/vesnin-patches/hostboot-p8/hostboot-1005-Allow-to-set-image-id-string-via-environment.patch
@@ -1,0 +1,32 @@
+From 2189114b15fbeb56a56463da2f842ac9972df48f Mon Sep 17 00:00:00 2001
+From: Artem Senichev <a.senichev@yadro.com>
+Date: Wed, 15 May 2019 15:13:30 +0300
+Subject: [PATCH] Allow to set image id string via environment
+
+Hostboot's Image Id is the first text string that a customer sees
+when the host starts booting.
+By default, image id is the version of hostboot itself, but it can be
+changed to any other value by setting HOSTBOOT_IMAGEID environment
+variable.
+
+Signed-off-by: Artem Senichev <a.senichev@yadro.com>
+---
+ src/build/tools/addimgid | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/build/tools/addimgid b/src/build/tools/addimgid
+index 09fcf171b..c3edd74aa 100755
+--- a/src/build/tools/addimgid
++++ b/src/build/tools/addimgid
+@@ -37,7 +37,7 @@ $imgBase =~ s/.*\///;
+ 
+ my $PREFIX = $ENV{'CROSS_PREFIX'};
+ my $address = hex `${PREFIX}nm $src -C | grep $imageIdSym | colrm 17`;
+-my $imageId = $ENV{'HOSTBOOT_VERSION'};
++my $imageId = $ENV{'HOSTBOOT_IMAGEID'};
+ if ($imageId eq '')
+ {
+     $imageId = $ENV{'HOSTBOOT_P8_VERSION'};
+-- 
+2.21.0
+


### PR DESCRIPTION
1. Remove duplicates of target machine name in the version string;
2. Hide error output during searching for OCC strings file;
3. Set hostboot image id using the firmware version.

End-user-impact: none

Signed-off-by: Artem Senichev <a.senichev@yadro.com>