### PR TITLE
nicole: Add testing support for standard PCIe hotplug

### DIFF
--- a/openpower/configs/nicole_defconfig
+++ b/openpower/configs/nicole_defconfig
@@ -2,6 +2,7 @@ BR2_powerpc64le=y
 BR2_powerpc_power8=y
 BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_4=y
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-targets=powerpc64-linux"
+BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_OP_BUILD_PATH)/patches/nicole-patches"
 BR2_GCC_VERSION_6_X=y
 BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-targets=powerpc64-linux --disable-libsanitizer"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y

--- a/openpower/patches/nicole-patches/skiboot/0001-core-pci-Add-functions-to-find-accessible-devices-by.patch
+++ b/openpower/patches/nicole-patches/skiboot/0001-core-pci-Add-functions-to-find-accessible-devices-by.patch
@@ -1,0 +1,212 @@
+From acb807c91405f3f6632d24735d1d464db679cd14 Mon Sep 17 00:00:00 2001
+From: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Fri, 1 Mar 2019 16:27:31 +0300
+Subject: [PATCH 1/7] core/pci: Add functions to find accessible devices by
+ bdfn
+
+During the PCIe re-enumeration by an OS the .bdfn field of the struct
+pci_device may not correspond to its device's actual address for a while,
+so the pci_find_dev() will return an invalid descriptor in this case. Some
+code may rely on this behavior, so this patch introduces a new function to
+return a descriptor for addressable devices only.
+
+This new function will help in discovering hotplugged devices.
+
+Here's a synthetic (but possible) scenario where pci_find_dev_safe() is
+different from pci_find_dev():
+
+I. Before the re-enumeration:
+
+ +-[0021:00]---00.0-[01-04]--+-00.0-[02]--
+                             +-01.0-[03]----00.0 Device Z1
+                             +-02.0-[04]--
+
+ - pci_find_dev(0021:03:00.0) returns correct struct pci_device *pd for
+   Device Z1;
+ - pci_find_dev_safe(0021:03:00.0) returns the same pd.
+
+II. Re-enumeration, step 1:
+
+                       _____ Dropped the bus numbers by writing zeros
+                      /
+ +-[0021:00]---00.0-[00-00]--+-00.0-[02]--
+                             +-01.0-[03]----00.0 Device Z1
+                             +-02.0-[04]--
+
+ - Device Z1 is unreachable (bus 1 is not assigned), but
+   pci_find_dev(0021:03:00.0) returns its pd;
+ - pci_find_dev_safe(0021:03:00.0) returns NULL.
+
+III. Re-enumeration, step 2:
+
+                      __ Update the bus numbers: primary <- 0,
+                     /   secondary <- 1, subordinate <- ff
+                    /
+ +-[0021:00]---00.0-[01-ff]--+-00.0-[02]--
+                             +-01.0-[03]----00.0 Device Z1
+                             +-02.0-[04]--
+
+ - By coincidence, pci_find_dev(0021:03:00.0) returns pd for Device Z1;
+ - pci_find_dev_safe(0021:03:00.0) returns pd for Device Z1, which is
+   correct by coincidence.
+
+IV. Re-enumeration, step 3:
+                                       ___ Drop the bus numbers
+                                      /
+ +-[0021:00]---00.0-[01-ff]--+-00.0-[00-00]--
+                             +-01.0-[00-00]----00.0 Device Z1
+                             +-02.0-[00-00]--
+
+ - Device Z1 is unreachable (downstream 0021:01:01.0 has no bus numbers
+   assigned), but pci_find_dev(0021:03:00.0) returns its uncorrected pd;
+ - pci_find_dev_safe(0021:03:00.0) returns NULL.
+
+V. Re-enumeration, step 4:
+
+               Set the bus numbers __           _ A phantom of Device Z1
+                                     \         / from pci_find_dev(03:00.0)
+ +-[0021:00]---00.0-[01-ff]--+-00.0-[02-06]-- -
+                             +-01.0-[00-00]----00.0 Device Z1
+                             +-02.0-[00-00]--
+
+ - pci_find_dev(0021:03:00.0) returns a phantom of the Device Z1 for wrong
+   address;
+ - pci_find_dev_safe(0021:03:00.0) returns NULL.
+
+VI. Re-enumeration, step 5:
+
+ +-[0021:00]---00.0-[01-ff]--+-00.0-[02-06]--
+                            -+-01.0-[07-0b]----00.0 Device Z1
+                           / +-02.0-[00-00]--
+     Set the bus numbers --
+
+ - pci_find_dev(0021:03:00.0) returns a phantom of the Device Z1;
+ - pci_find_dev_safe(0021:03:00.0) returns NULL;
+ - pci_find_dev_safe(0021:07:00.0) returns pd for the Device Z1, but its
+   .bdfn field needs to be corrected (by the following patch).
+
+VI. After the re-enumeration:
+
+ +-[0021:00]---00.0-[01-10]--+-00.0-[02-06]--
+                             +-01.0-[07-0b]----00.0 Device Z1
+                             +-02.0-[0c-10]--
+
+Even though the .bdfn field is not correct at the moment, it is clear that
+this is a previously known device, not a hotplugged one.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ core/pci.c    | 83 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ include/pci.h |  2 ++
+ 2 files changed, 85 insertions(+)
+
+diff --git a/core/pci.c b/core/pci.c
+index e195ecbf..d443f935 100644
+--- a/core/pci.c
++++ b/core/pci.c
+@@ -1826,6 +1826,89 @@ struct pci_device *pci_find_dev(struct phb *phb, uint16_t bdfn)
+ 	return pci_walk_dev(phb, NULL, __pci_find_dev, &bdfn);
+ }
+ 
++static struct pci_device *__pci_find_parent(struct pci_device *pd, uint8_t bus)
++{
++	struct pci_device *child;
++
++	if (!pd)
++		return NULL;
++
++	if (pd->secondary_bus == bus)
++		return pd;
++
++	if (bus < pd->secondary_bus || bus > pd->subordinate_bus)
++		return NULL;
++
++	list_for_each(&pd->children, child, link) {
++		if (child->secondary_bus == bus)
++			return child;
++	}
++
++	list_for_each(&pd->children, child, link) {
++		struct pci_device *found = __pci_find_parent(child, bus);
++
++		if (found)
++			return found;
++	}
++
++	return NULL;
++}
++
++struct pci_device *pci_find_parent_dev(struct phb *phb, uint16_t bdfn)
++{
++	struct pci_device *pd;
++	uint8_t bus = PCI_BUS_NUM(bdfn);
++
++	if (!phb)
++		return NULL;
++
++	list_for_each(&phb->devices, pd, link) {
++		struct pci_device *found = __pci_find_parent(pd, bus);
++
++		if (found)
++			return found;
++	}
++
++	return NULL;
++}
++
++struct pci_device *pci_find_dev_safe(struct phb *phb, uint16_t bdfn)
++{
++	struct pci_device *parent;
++	struct pci_device *child;
++
++	if (!phb)
++		return NULL;
++
++	if (!bdfn) {
++		struct pci_device *pd;
++
++		list_for_each(&phb->devices, pd, link) {
++			if (pd->bdfn == bdfn)
++				return pd;
++		}
++	}
++
++	parent = pci_find_parent_dev(phb, bdfn);
++	if (!parent)
++		return NULL;
++
++	list_for_each(&parent->children, child, link) {
++		if ((child->bdfn & 0xff) == (bdfn & 0xff)) {
++			if (child->bdfn != bdfn) {
++				PCIERR(phb, bdfn, "pci_device has invalid bdfn field %04x:%02x:%02x.%d\n",
++				       phb->opal_id,
++				       PCI_BUS_NUM(child->bdfn),
++				       PCI_DEV(child->bdfn),
++				       PCI_FUNC(child->bdfn));
++			}
++			return child;
++		}
++	}
++
++	return NULL;
++}
++
+ static int __pci_restore_bridge_buses(struct phb *phb,
+ 				      struct pci_device *pd,
+ 				      void *data __unused)
+diff --git a/include/pci.h b/include/pci.h
+index eb23a6d9..e34d24ff 100644
+--- a/include/pci.h
++++ b/include/pci.h
+@@ -462,6 +462,8 @@ extern struct pci_device *pci_walk_dev(struct phb *phb,
+ 						 void *),
+ 				       void *userdata);
+ extern struct pci_device *pci_find_dev(struct phb *phb, uint16_t bdfn);
++extern struct pci_device *pci_find_dev_safe(struct phb *phb, uint16_t bdfn);
++extern struct pci_device *pci_find_parent_dev(struct phb *phb, uint16_t bdfn);
+ extern void pci_restore_bridge_buses(struct phb *phb, struct pci_device *pd);
+ extern struct pci_cfg_reg_filter *pci_find_cfg_reg_filter(struct pci_device *pd,
+ 					uint32_t start, uint32_t len);
+-- 
+2.24.1
+

--- a/openpower/patches/nicole-patches/skiboot/0002-core-pci-Make-the-pci_scan_one-function-public.patch
+++ b/openpower/patches/nicole-patches/skiboot/0002-core-pci-Make-the-pci_scan_one-function-public.patch
@@ -1,0 +1,45 @@
+From 3d6e773d1bbbacb5fe32a4227556f3b0651ddf24 Mon Sep 17 00:00:00 2001
+From: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Fri, 1 Mar 2019 16:27:36 +0300
+Subject: [PATCH 2/7] core/pci: Make the pci_scan_one() function public
+
+This change will be used by the next commit to discover new PCI devices and
+to create struct pci_device for them.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ core/pci.c    | 4 ++--
+ include/pci.h | 2 ++
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/core/pci.c b/core/pci.c
+index d443f935..77424b3e 100644
+--- a/core/pci.c
++++ b/core/pci.c
+@@ -219,8 +219,8 @@ bool pci_wait_crs(struct phb *phb, uint16_t bdfn, uint32_t *out_vdid)
+ 	return true;
+ }
+ 
+-static struct pci_device *pci_scan_one(struct phb *phb, struct pci_device *parent,
+-				       uint16_t bdfn)
++struct pci_device *pci_scan_one(struct phb *phb, struct pci_device *parent,
++				uint16_t bdfn)
+ {
+ 	struct pci_device *pd = NULL;
+ 	uint32_t vdid;
+diff --git a/include/pci.h b/include/pci.h
+index e34d24ff..29ecdddd 100644
+--- a/include/pci.h
++++ b/include/pci.h
+@@ -443,6 +443,8 @@ extern void pci_remove_bus(struct phb *phb, struct list_head *list);
+ extern uint8_t pci_scan_bus(struct phb *phb, uint8_t bus, uint8_t max_bus,
+ 			    struct list_head *list, struct pci_device *parent,
+ 			    bool scan_downstream);
++extern struct pci_device *pci_scan_one(struct phb *phb, struct pci_device *parent,
++				       uint16_t bdfn);
+ extern void pci_add_device_nodes(struct phb *phb,
+ 				 struct list_head *list,
+ 				 struct dt_node *parent_node,
+-- 
+2.24.1
+

--- a/openpower/patches/nicole-patches/skiboot/0003-core-pci-Create-the-struct-pci_device-nodes-automati.patch
+++ b/openpower/patches/nicole-patches/skiboot/0003-core-pci-Create-the-struct-pci_device-nodes-automati.patch
@@ -1,0 +1,77 @@
+From d921a31f8ee7cd1c5b1d88a08b9537d4b797b65d Mon Sep 17 00:00:00 2001
+From: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Fri, 1 Mar 2019 16:27:39 +0300
+Subject: [PATCH 3/7] core/pci: Create the struct pci_device nodes
+ automatically
+
+Currently the struct pci_device nodes are created only during the bus
+rescan in skiboot (pci_scan_bus) initiated by an OS via OPAL. But these
+structures also could be created if reading the configuration space via
+OPAL reveals a new hotplugged device.
+
+This will allow using the standard platform-independent PCIe hotplug driver
+in Linux kernel ("pciehp") instead of requesting a Device Tree update.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ core/pci-opal.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/core/pci-opal.c b/core/pci-opal.c
+index aa375c6a..0ec9bcdd 100644
+--- a/core/pci-opal.c
++++ b/core/pci-opal.c
+@@ -14,13 +14,21 @@
+ #include <timebase.h>
+ #include <timer.h>
+ 
++static struct pci_device *pci_create_dn(struct phb *phb, uint16_t bdfn)
++{
++	struct pci_device *parent = pci_find_parent_dev(phb, bdfn);
++
++	return pci_scan_one(phb, parent, bdfn);
++}
++
+ #define OPAL_PCICFG_ACCESS_READ(op, cb, type)	\
+ static int64_t opal_pci_config_##op(uint64_t phb_id,			\
+ 				    uint64_t bus_dev_func,		\
+-				    uint64_t offset, type data)		\
++				    uint64_t offset, type *data)	\
+ {									\
+ 	struct phb *phb = pci_get_phb(phb_id);				\
+ 	int64_t rc;							\
++	bool dev_found;							\
+ 									\
+ 	if (!opal_addr_valid((void *)data))				\
+ 		return OPAL_PARAMETER;					\
+@@ -28,7 +36,14 @@ static int64_t opal_pci_config_##op(uint64_t phb_id,			\
+ 	if (!phb)							\
+ 		return OPAL_PARAMETER;					\
+ 	phb_lock(phb);							\
++									\
++	dev_found = pci_find_dev_safe(phb, bus_dev_func);		\
++									\
+ 	rc = phb->ops->cfg_##cb(phb, bus_dev_func, offset, data);	\
++									\
++	if (!rc && !dev_found && *data != (type)0xffffffff)		\
++		pci_create_dn(phb, bus_dev_func);			\
++									\
+ 	phb_unlock(phb);						\
+ 									\
+ 	return rc;							\
+@@ -51,9 +66,9 @@ static int64_t opal_pci_config_##op(uint64_t phb_id,			\
+ 	return rc;							\
+ }
+ 
+-OPAL_PCICFG_ACCESS_READ(read_byte,		read8, uint8_t *)
+-OPAL_PCICFG_ACCESS_READ(read_half_word,		read16, uint16_t *)
+-OPAL_PCICFG_ACCESS_READ(read_word,		read32, uint32_t *)
++OPAL_PCICFG_ACCESS_READ(read_byte,		read8, uint8_t)
++OPAL_PCICFG_ACCESS_READ(read_half_word,		read16, uint16_t)
++OPAL_PCICFG_ACCESS_READ(read_word,		read32, uint32_t)
+ OPAL_PCICFG_ACCESS_WRITE(write_byte,		write8, uint8_t)
+ OPAL_PCICFG_ACCESS_WRITE(write_half_word,	write16, uint16_t)
+ OPAL_PCICFG_ACCESS_WRITE(write_word,		write32, uint32_t)
+-- 
+2.24.1
+

--- a/openpower/patches/nicole-patches/skiboot/0004-core-pci-Hook-up-the-writes-to-PRIMARY-SECONDARY-SUB.patch
+++ b/openpower/patches/nicole-patches/skiboot/0004-core-pci-Hook-up-the-writes-to-PRIMARY-SECONDARY-SUB.patch
@@ -1,0 +1,132 @@
+From e968adf90e7201b65f69d94c86dfedc1f5d17da6 Mon Sep 17 00:00:00 2001
+From: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Fri, 1 Mar 2019 16:27:46 +0300
+Subject: [PATCH 4/7] core/pci: Hook up the writes to
+ PRIMARY/SECONDARY/SUBORDINATE_BUS registers
+
+When Linux kernel boots with the "pci=realloc" command line argument, it
+re-enumerates the PCIe topology first by dropping all the bridge's
+downstream port's bus numbers to zero, and then assigns the newly
+calculated bus numbers:
+
+pci_scan_bridge_extend()
+    if (pcibios_assign_all_busses())
+        pci_write_config_dword(dev, PCI_PRIMARY_BUS,
+                               buses & ~0xffffff);
+        ...
+        buses = ...
+        ...
+        pci_write_config_dword(dev, PCI_PRIMARY_BUS, buses);
+
+But this leaves the corresponding struct pci_device entries in the skiboot
+de-synchronized with actual values in bridge's registers.
+
+This patch intercepts the write requests to the PCI_CFG_PRIMARY_BUS,
+PCI_CFG_SECONDARY_BUS and PCI_CFG_SUBORDINATE_BUS registers, updating the
+bdfn, primary_bus, secondary_bus and subordinate_bus fields.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ core/pci-opal.c | 78 ++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 77 insertions(+), 1 deletion(-)
+
+diff --git a/core/pci-opal.c b/core/pci-opal.c
+index 0ec9bcdd..0c9de1c1 100644
+--- a/core/pci-opal.c
++++ b/core/pci-opal.c
+@@ -49,6 +49,80 @@ static int64_t opal_pci_config_##op(uint64_t phb_id,			\
+ 	return rc;							\
+ }
+ 
++static void pci_update_children_bdfns(struct pci_device *pd)
++{
++	struct pci_device *child;
++
++	list_for_each(&pd->children, child, link) {
++		uint16_t new_bdfn = (child->bdfn & 0xff) | (pd->secondary_bus << 8);
++
++		if (child->bdfn != new_bdfn || child->primary_bus != pd->secondary_bus) {
++			if (!list_empty(&child->pcrf) && child->primary_bus)
++				bitmap_clr_bit(*child->phb->filter_map, child->bdfn);
++
++			child->bdfn = new_bdfn;
++			child->primary_bus = pd->secondary_bus;
++
++			if (!list_empty(&child->pcrf) && child->primary_bus)
++				bitmap_set_bit(*child->phb->filter_map, child->bdfn);
++
++			if (child->primary_bus && child->slot)
++				child->slot->id = PCI_SLOT_ID(child->phb, child->bdfn);
++		}
++	}
++}
++
++static void opal_pci_config_write_hook(struct phb *phb, uint16_t bdfn, uint64_t offset,
++				       uint32_t data, uint32_t size)
++{
++	struct pci_device *pd;
++	uint8_t old_sec;
++
++	if (data == 0xffffffff)
++		return;
++
++	pd = pci_find_dev_safe(phb, bdfn);
++	if (!pd) {
++		pd = pci_create_dn(phb, bdfn);
++		return;
++	}
++
++	switch (offset) {
++	case PCI_CFG_PRIMARY_BUS:
++	case PCI_CFG_SECONDARY_BUS:
++	case PCI_CFG_SUBORDINATE_BUS:
++		break;
++
++	default:
++		return;
++	}
++
++	old_sec = pd->secondary_bus;
++
++	switch (offset) {
++	case PCI_CFG_PRIMARY_BUS:
++		pd->primary_bus = data & 0xff;
++
++		if (size == 4) {
++			pd->secondary_bus = (data >> 8) & 0xff;
++			pd->subordinate_bus = (data >> 16) & 0xff;
++		}
++		break;
++
++	case PCI_CFG_SECONDARY_BUS:
++		pd->secondary_bus = data & 0xff;
++		break;
++
++	case PCI_CFG_SUBORDINATE_BUS:
++		pd->subordinate_bus = data & 0xff;
++		break;
++	}
++
++	if (pd->is_bridge && old_sec != pd->secondary_bus) {
++		pci_update_children_bdfns(pd);
++	}
++}
++
+ #define OPAL_PCICFG_ACCESS_WRITE(op, cb, type)	\
+ static int64_t opal_pci_config_##op(uint64_t phb_id,			\
+ 				    uint64_t bus_dev_func,		\
+@@ -59,8 +133,10 @@ static int64_t opal_pci_config_##op(uint64_t phb_id,			\
+ 									\
+ 	if (!phb)							\
+ 		return OPAL_PARAMETER;					\
+-	phb_lock(phb);						\
++	phb_lock(phb);							\
+ 	rc = phb->ops->cfg_##cb(phb, bus_dev_func, offset, data);	\
++	opal_pci_config_write_hook(phb, bus_dev_func, offset, data,	\
++				   sizeof(type));			\
+ 	phb_unlock(phb);						\
+ 									\
+ 	return rc;							\
+-- 
+2.24.1
+

--- a/openpower/patches/nicole-patches/skiboot/0005-core-pci-Indicate-support-for-PCI-re-enumeration.patch
+++ b/openpower/patches/nicole-patches/skiboot/0005-core-pci-Indicate-support-for-PCI-re-enumeration.patch
@@ -1,0 +1,28 @@
+From 9adb468e7bccfae021a9520f019962559b88f34e Mon Sep 17 00:00:00 2001
+From: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Wed, 3 Jul 2019 11:22:15 +0300
+Subject: [PATCH 5/7] core/pci: Indicate support for PCI re-enumeration
+
+New PHB's property "ibm,supported-movable-bdfs" shows that skiboot now
+supports changing PCI bus numbers.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ core/pci.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/core/pci.c b/core/pci.c
+index 77424b3e..d556189c 100644
+--- a/core/pci.c
++++ b/core/pci.c
+@@ -1046,6 +1046,7 @@ int64_t pci_register_phb(struct phb *phb, int opal_id)
+ 	if (opal_id > last_phb_id)
+ 		last_phb_id = opal_id;
+ 	dt_add_property_cells(phb->dt_node, "ibm,opal-phbid", 0, phb->opal_id);
++	dt_add_property(phb->dt_node, "ibm,supported-movable-bdfs", NULL, 0);
+ 	PCIDBG(phb, 0, "PCI: Registered PHB\n");
+ 
+ 	init_lock(&phb->lock);
+-- 
+2.24.1
+

--- a/openpower/patches/nicole-patches/skiboot/0006-hw-phb4-Don-t-force-the-link-to-be-killed-after-erro.patch
+++ b/openpower/patches/nicole-patches/skiboot/0006-hw-phb4-Don-t-force-the-link-to-be-killed-after-erro.patch
@@ -1,0 +1,32 @@
+From e68b09257d748454e03b04b68137066a06261c7d Mon Sep 17 00:00:00 2001
+From: Sergei Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Wed, 10 Jun 2020 14:51:33 +0300
+Subject: [PATCH 6/7] hw/phb4: Don't force the link to be killed after errors
+
+When EEH is disabled (to have DPC and pciehp), link status is not polled,
+so when a removed PCI device is back, make it accessible.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ hw/phb4.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/hw/phb4.c b/hw/phb4.c
+index 3f22a2c4..05a8f9c8 100644
+--- a/hw/phb4.c
++++ b/hw/phb4.c
+@@ -2273,9 +2273,8 @@ static void phb4_prepare_link_change(struct pci_slot *slot, bool is_up)
+ 		/* Don't block PCI-CFG */
+ 		p->flags &= ~PHB4_CFG_BLOCKED;
+ 
+-		/* Re-enable link down errors */
+-		out_be64(p->regs + PHB_PCIE_MISC_STRAP,
+-			 0x0000060000000000ull);
++		/* Don't force the link to be 'killed' after errors */
++		out_be64(p->regs + PHB_PCIE_MISC_STRAP, 0);
+ 
+ 		/* Re-enable error status indicators that trigger irqs */
+ 		out_be64(p->regs + PHB_REGB_ERR_INF_ENABLE,
+-- 
+2.24.1
+

--- a/openpower/patches/nicole-patches/skiboot/0007-hw-phb4-Decode-some-common-error-bits-when-dumping-r.patch
+++ b/openpower/patches/nicole-patches/skiboot/0007-hw-phb4-Decode-some-common-error-bits-when-dumping-r.patch
@@ -1,0 +1,178 @@
+From 5e59bd74bd8df3248e3330c3748ae0c37ed7721b Mon Sep 17 00:00:00 2001
+From: Sergei Miroshnichenko <s.miroshnichenko@yadro.com>
+Date: Tue, 16 Jun 2020 11:57:48 +0300
+Subject: [PATCH 7/7] hw/phb4: Decode some common error bits when dumping
+ registers
+
+Manual deciphering of register values is unbearable, so decode at least
+some of them automatically.
+
+Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>
+---
+ hw/phb4.c | 111 +++++++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 105 insertions(+), 6 deletions(-)
+
+diff --git a/hw/phb4.c b/hw/phb4.c
+index 05a8f9c8..9bccaf53 100644
+--- a/hw/phb4.c
++++ b/hw/phb4.c
+@@ -2088,11 +2088,100 @@ static void __unused phb4_dump_ioda_table(struct phb4 *p, int table)
+ 	PHBERR(p, "End %s dump\n", name);
+ }
+ 
++struct bit_desc {
++	int bit;
++	const char *desc;
++};
++
++static struct bit_desc phbErrorStatusDesc[] = {
++	{ 20, "RXE_ARB OR Error Status" },
++	{ 21, "RXE_MRG OR Error Status" },
++	{ 22, "RXE_TCE OR Error Status" },
++	{ 23, "TXE OR Error Status" },
++	{ 24, "Error signal from PCIE/REGB. INF" },
++	{ 25, "Error signal from PCIE/REGB. ER (ALL)" },
++	{ 26, "Error signal from PCIE/REGB. Fatal" },
++	{ 27, "Internal register bus write data parity error" },
++};
++
++static struct bit_desc phbTxeErrorStatusDesc[] = {
++	{ 16, "BLIF Controls Parity Error" },
++	{ 17, "CFG Write Error CA or UR response" },
++	{ 18, "BLIF Forward Progress Timeout" },
++	{ 19, "MMIO RD Pending Error" },
++	{ 24, "A CFG access was attempted but the Enable bit was not set" },
++	{ 25, "CFG Size Error" },
++	{ 26, "CFG Bus Address Error" },
++	{ 27, "CFG Link Down Error" },
++};
++
++static struct bit_desc phbRxeArbErrorStatusDesc[] = {
++	{ 0, "BLIF Inbound CA Completion Error" },
++	{ 1, "BLIF Inbound UR Completion Error" },
++	{ 2, "MSI Size Error" },
++	{ 3, "MSI Address Alignment Error" },
++	{ 16, "BLIF Header Control Bits Parity Error" },
++	{ 17, "BLIF Data Control Bits Parity Error" },
++	{ 18, "BLIF Unsupported Request (UR) Error" },
++	{ 19, "BLIF Completion Timeout Error" },
++	{ 32, "PELT-V BAR Disabled Error" },
++	{ 33, "IODA Table Parity Error" },
++	{ 34, "PCT Timeout" },
++	{ 35, "PCT Unexpected Completion" },
++};
++
++static struct bit_desc phbRxeTceErrorStatusDesc[] = {
++	{ 0, "TCE CMP Internal Parity Error" },
++	{ 1, "TCE Request Page Access Error" },
++	{ 2, "TCE Response Page Access Error" },
++	{ 3, "TCE CMP Queue Overflow" },
++};
++
++static struct bit_desc phbRegbErrorStatusDesc[] = {
++	{ 8, "PCIE Link Down" },
++	{ 9, "PCIE Link Up" },
++	{ 10, "PCIE Link Auto Bandwidth Event Status" },
++	{ 11, "PCIE Link BW Management Event Status (Silent Retrain)" },
++	{ 25, "PBL Error Trap: INF Error. INF" },
++	{ 26, "PBL Error Trap: ERC Error. INF" },
++	{ 27, "PBL Error Trap: FAT Error. Fatal" },
++	{ 28, "tldlpo_dl_mon_rxreceivererror(0)" },
++	{ 29, "tldlpo_dl_mon_rxreceivererror(1)" },
++	{ 30, "tldlpo_dl_mon_rxreceivererror(2)" },
++	{ 32, "TLDLP core detected a bad DLLP packet" },
++	{ 33, "TLDLP core detected a bad TLP packet" },
++	{ 34, "TLDLP core detected a Data Link Layer Protocol Error" },
++	{ 35, "TLDLP core detected a Receiver Error on the link" },
++	{ 40, "DL_LB_ERROR" },
++	{ 41, "TLDLP core indicates it received a TLP that was malformed" },
++	{ 42, "TLDLP core indicates it received a TLP that was nullified by the transmitter" },
++	{ 43, "Asserted to indicate that the TLP in-progress has overflowed its receiver buffer" },
++};
++
++static void phb4_eeh_describe_reg(struct phb4 *p, const char *name, uint64_t v, const struct bit_desc *d, size_t d_size)
++{
++	unsigned int i;
++
++	for (i = 0; i < d_size; ++i) {
++		uint64_t bit = PPC_BIT(d[i].bit);
++
++		if (!(v & bit))
++			continue;
++
++		PHBERR(p, "%s: %02d: %s\n", name, d[i].bit, d[i].desc);
++		v &= ~bit;
++	}
++
++	if (v)
++		PHBERR(p, "%s: and more\n", name);
++}
++
+ static void phb4_eeh_dump_regs(struct phb4 *p)
+ {
+ 	struct OpalIoPhb4ErrorData *s;
+ 	uint16_t reg;
+ 	unsigned int i;
++	uint64_t phbErrorStatus, phbTxeErrorStatus, phbRxeArbErrorStatus, phbRxeTceErrorStatus, phbRegbErrorStatus;
+ 
+ 	if (!verbose_eeh)
+ 		return;
+@@ -2104,6 +2193,12 @@ static void phb4_eeh_dump_regs(struct phb4 *p)
+ 	}
+ 	phb4_read_phb_status(p, s);
+ 
++	phbErrorStatus          = be64_to_cpu(s->phbErrorStatus);
++	phbTxeErrorStatus       = be64_to_cpu(s->phbTxeErrorStatus);
++	phbRxeArbErrorStatus    = be64_to_cpu(s->phbRxeArbErrorStatus);
++	phbRxeTceErrorStatus	= be64_to_cpu(s->phbRxeTceErrorStatus);
++	phbRegbErrorStatus      = be64_to_cpu(s->phbRegbErrorStatus);
++
+ 	PHBERR(p, "                 brdgCtl = %08x\n", be32_to_cpu(s->brdgCtl));
+ 
+ 	/* PHB4 cfg regs */
+@@ -2137,15 +2232,18 @@ static void phb4_eeh_dump_regs(struct phb4 *p)
+ 	PHBERR(p, "                  lemFir = %016llx\n", be64_to_cpu(s->lemFir));
+ 	PHBERR(p, "            lemErrorMask = %016llx\n", be64_to_cpu(s->lemErrorMask));
+ 	PHBERR(p, "                  lemWOF = %016llx\n", be64_to_cpu(s->lemWOF));
+-	PHBERR(p, "          phbErrorStatus = %016llx\n", be64_to_cpu(s->phbErrorStatus));
++	PHBERR(p, "          phbErrorStatus = %016llx\n", phbErrorStatus);
++	phb4_eeh_describe_reg(p, "phbErrorStatus", phbErrorStatus, phbErrorStatusDesc, ARRAY_SIZE(phbErrorStatusDesc));
+ 	PHBERR(p, "     phbFirstErrorStatus = %016llx\n", be64_to_cpu(s->phbFirstErrorStatus));
+ 	PHBERR(p, "            phbErrorLog0 = %016llx\n", be64_to_cpu(s->phbErrorLog0));
+ 	PHBERR(p, "            phbErrorLog1 = %016llx\n", be64_to_cpu(s->phbErrorLog1));
+-	PHBERR(p, "       phbTxeErrorStatus = %016llx\n", be64_to_cpu(s->phbTxeErrorStatus));
++	PHBERR(p, "       phbTxeErrorStatus = %016llx\n", phbTxeErrorStatus);
++	phb4_eeh_describe_reg(p, "phbTxeErrorStatus", phbTxeErrorStatus, phbTxeErrorStatusDesc, ARRAY_SIZE(phbTxeErrorStatusDesc));
+ 	PHBERR(p, "  phbTxeFirstErrorStatus = %016llx\n", be64_to_cpu(s->phbTxeFirstErrorStatus));
+ 	PHBERR(p, "         phbTxeErrorLog0 = %016llx\n", be64_to_cpu(s->phbTxeErrorLog0));
+ 	PHBERR(p, "         phbTxeErrorLog1 = %016llx\n", be64_to_cpu(s->phbTxeErrorLog1));
+-	PHBERR(p, "    phbRxeArbErrorStatus = %016llx\n", be64_to_cpu(s->phbRxeArbErrorStatus));
++	PHBERR(p, "    phbRxeArbErrorStatus = %016llx\n", phbRxeArbErrorStatus);
++	phb4_eeh_describe_reg(p, "phbRxeArbErrorStatusDesc", phbRxeArbErrorStatus, phbRxeArbErrorStatusDesc, ARRAY_SIZE(phbRxeArbErrorStatusDesc));
+ 	PHBERR(p, "phbRxeArbFrstErrorStatus = %016llx\n", be64_to_cpu(s->phbRxeArbFirstErrorStatus));
+ 	PHBERR(p, "      phbRxeArbErrorLog0 = %016llx\n", be64_to_cpu(s->phbRxeArbErrorLog0));
+ 	PHBERR(p, "      phbRxeArbErrorLog1 = %016llx\n", be64_to_cpu(s->phbRxeArbErrorLog1));
+@@ -2153,7 +2251,8 @@ static void phb4_eeh_dump_regs(struct phb4 *p)
+ 	PHBERR(p, "phbRxeMrgFrstErrorStatus = %016llx\n", be64_to_cpu(s->phbRxeMrgFirstErrorStatus));
+ 	PHBERR(p, "      phbRxeMrgErrorLog0 = %016llx\n", be64_to_cpu(s->phbRxeMrgErrorLog0));
+ 	PHBERR(p, "      phbRxeMrgErrorLog1 = %016llx\n", be64_to_cpu(s->phbRxeMrgErrorLog1));
+-	PHBERR(p, "    phbRxeTceErrorStatus = %016llx\n", be64_to_cpu(s->phbRxeTceErrorStatus));
++	PHBERR(p, "    phbRxeTceErrorStatus = %016llx\n", phbRxeTceErrorStatus);
++	phb4_eeh_describe_reg(p, "phbRxeTceErrorStatus", phbRxeTceErrorStatus, phbRxeTceErrorStatusDesc, ARRAY_SIZE(phbRxeTceErrorStatusDesc));
+ 	PHBERR(p, "phbRxeTceFrstErrorStatus = %016llx\n", be64_to_cpu(s->phbRxeTceFirstErrorStatus));
+ 	PHBERR(p, "      phbRxeTceErrorLog0 = %016llx\n", be64_to_cpu(s->phbRxeTceErrorLog0));
+ 	PHBERR(p, "      phbRxeTceErrorLog1 = %016llx\n", be64_to_cpu(s->phbRxeTceErrorLog1));
+@@ -2164,8 +2263,8 @@ static void phb4_eeh_dump_regs(struct phb4 *p)
+ 	PHBERR(p, "     phbPcieDlpErrorLog1 = %016llx\n", be64_to_cpu(s->phbPcieDlpErrorLog1));
+ 	PHBERR(p, "     phbPcieDlpErrorLog2 = %016llx\n", be64_to_cpu(s->phbPcieDlpErrorLog2));
+ 	PHBERR(p, "   phbPcieDlpErrorStatus = %016llx\n", be64_to_cpu(s->phbPcieDlpErrorStatus));
+-
+-	PHBERR(p, "      phbRegbErrorStatus = %016llx\n", be64_to_cpu(s->phbRegbErrorStatus));
++	PHBERR(p, "      phbRegbErrorStatus = %016llx\n", phbRegbErrorStatus);
++	phb4_eeh_describe_reg(p, "phbRegbErrorStatus", phbRegbErrorStatus, phbRegbErrorStatusDesc, ARRAY_SIZE(phbRegbErrorStatusDesc));
+ 	PHBERR(p, " phbRegbFirstErrorStatus = %016llx\n", be64_to_cpu(s->phbRegbFirstErrorStatus));
+ 	PHBERR(p, "        phbRegbErrorLog0 = %016llx\n", be64_to_cpu(s->phbRegbErrorLog0));
+ 	PHBERR(p, "        phbRegbErrorLog1 = %016llx\n", be64_to_cpu(s->phbRegbErrorLog1));
+-- 
+2.24.1
+


### PR DESCRIPTION
An OS may re-enumerate the PCIe tree during boot and after hot-plugging a
bridge, but this leads to de-sync of the cached and actual BDF addresses.

Track the changes in bus numbering and update the cached topology (a tree
consisting of struct pci_device nodes) correspondingly, including PEs.

Append the cached topology when reading a config space reveals a hot-added
device, with no need for an explicit OPAL call for that.

Tested on the Nicole platform with Linux kernel 5.7.0 patched for using the
standard pciehp hotplug driver and sysfs rescan instead of the pnv_php driver.

Signed-off-by: Sergey Miroshnichenko <s.miroshnichenko@yadro.com>