### PR TITLE
nicole: Force start degraded RAID

### DIFF
--- a/openpower/overlay/lib/udev/rules.d/64-mdraid.rules
+++ b/openpower/overlay/lib/udev/rules.d/64-mdraid.rules
@@ -1,0 +1,8 @@
+# Udev rules for mdraid devices.
+#
+# Normally if not all the expected drives are found, then the array will be
+# assembled but not started. The following rule forces an inactive array to
+# start.
+ACTION=="add|change", KERNEL=="md127", SUBSYSTEM=="block", \
+  PROGRAM="/bin/sh -c '/sbin/mdadm --detail --brief /dev/%k | /bin/grep -q INACTIVE'", \
+  RUN+="/sbin/mdadm --run /dev/%k"


### PR DESCRIPTION
Normally if not all the expected drives are found, then the array will
be assembled but not started (see man mdadm for details).
Tatlin uses mdraid (RAID1) for the boot partition. This patch adds an
udev rule to force start the array.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>