### PR TITLE
Adds support for 4 versions of SBE

### DIFF
--- a/openpower/patches/nicole-patches/openpower-pnor/0001-Expand-SBE-region.patch
+++ b/openpower/patches/nicole-patches/openpower-pnor/0001-Expand-SBE-region.patch
@@ -1,0 +1,47 @@
+From d0b0e02c19bf7ba4f3db7f2d75438cebc26c6d9a Mon Sep 17 00:00:00 2001
+From: Konstantin Yurchenko <k.yurchenko@yadro.com>
+Date: Mon, 19 Dec 2022 12:42:51 +0300
+Subject: [PATCH] Expand SBE region
+
+Increases the size of the SBE region by decreasing the size of
+the HCODE region and shifting its base address.
+
+Signed-off-by: Konstantin Yurchenko <k.yurchenko@yadro.com>
+---
+ p9Layouts/defaultPnorLayout_64.xml | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/p9Layouts/defaultPnorLayout_64.xml b/p9Layouts/defaultPnorLayout_64.xml
+index 1e74c51..b78bc93 100644
+--- a/p9Layouts/defaultPnorLayout_64.xml
++++ b/p9Layouts/defaultPnorLayout_64.xml
+@@ -182,10 +182,10 @@ Layout Description
+         <ecc/>
+     </section>
+     <section>
+-        <description>SBE-IPL (Staging Area) (520K)</description>
++        <description>SBE-IPL (Staging Area) (0.98MB)</description>
+         <eyeCatch>SBE</eyeCatch>
+         <physicalOffset>0x16E5000</physicalOffset>
+-        <physicalRegionSize>0xBC000</physicalRegionSize>
++        <physicalRegionSize>0xFC000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+         <sha512perEC/>
+@@ -193,10 +193,10 @@ Layout Description
+         <ecc/>
+     </section>
+     <section>
+-        <description>HCODE Ref Image (1.125MB)</description>
++        <description>HCODE Ref Image (0.88MB)</description>
+         <eyeCatch>HCODE</eyeCatch>
+-        <physicalOffset>0x17A1000</physicalOffset>
+-        <physicalRegionSize>0x120000</physicalRegionSize>
++        <physicalOffset>0x17E1000</physicalOffset>
++        <physicalRegionSize>0xE0000</physicalRegionSize>
+         <side>A</side>
+         <sha512Version/>
+         <readOnly/>
+-- 
+2.38.1
+

--- a/openpower/patches/nicole-patches/sbe/0001-Add-support-for-4-versions-of-SBE.patch
+++ b/openpower/patches/nicole-patches/sbe/0001-Add-support-for-4-versions-of-SBE.patch
@@ -1,17 +1,17 @@
-From a1bc15a3c44b21e658fbef940082e46f3e8f7007 Mon Sep 17 00:00:00 2001
-From: Artem Senichev <artemsen@gmail.com>
-Date: Tue, 25 Oct 2022 12:55:14 +0300
-Subject: [PATCH] Bring back DD 2.0 support
+From 8cd227fe6f0abc7ba696bac82254154ad25d2f77 Mon Sep 17 00:00:00 2001
+From: Konstantin Yurchenko <k.yurchenko@yadro.com>
+Date: Tue, 13 Dec 2022 15:19:44 +0300
+Subject: [PATCH] Add support for 4 versions of SBE
 
-Allows to use old processors on Nicole machines.
+Adds support for four SBE versions: 2.0, 2.1, 2.2 and 2.3.
 
-Signed-off-by: Artem Senichev <artemsen@gmail.com>
+Signed-off-by: Konstantin Yurchenko <k.yurchenko@yadro.com>
 ---
  src/build/sbeOpDistribute.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/build/sbeOpDistribute.py b/src/build/sbeOpDistribute.py
-index cb735b732..ea51e2fd1 100755
+index cb735b732..320f67136 100755
 --- a/src/build/sbeOpDistribute.py
 +++ b/src/build/sbeOpDistribute.py
 @@ -90,7 +90,7 @@ def main(argv):
@@ -19,7 +19,7 @@ index cb735b732..ea51e2fd1 100755
      #input SBE binary name.
      CHIPID = 'p9n'
 -    eclist = {'21':'DD2', '22':'DD2', '23':'DD2'}
-+    eclist = {'20':'DD2', '21':'DD2', '22':'DD2'}
++    eclist = {'20':'DD2', '21':'DD2', '22':'DD2', '23':'DD2'}
  
      #Update if the script is called for Axone chips
      if (sbe_binary_filename == "axone_sbe.img.ecc"):


### PR DESCRIPTION
Extends the SBE region and adds a fourth type of processor support. The following SBE versions are supported: 2.0, 2.1, 2.2 and 2.3.

Signed-off-by: Konstantin Yurchenko <k.yurchenko@yadro.com>